### PR TITLE
Fix null and undefined behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memcached-typed",
-  "version": "6.0.1",
-  "description": "Typescript Memcached Wrapper, with Promise and Template helper",
+  "version": "7.0.0",
+  "description": "Typescript cached fetching helper",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",
   "scripts": {


### PR DESCRIPTION
# AS-IS
if you return null or undefined on fetcher, currently
1. null
fetcher caches it on driver, but don't give that value to user.
2. undefined
fetcher caches it on driver, but as "" (empty string). 

# TO-BE
1. null 
fetcher caches as "null" value
2. undefined
fetcher ignores it, don't cache it
